### PR TITLE
Work on ironing out the fine detail of support for several new construct entities

### DIFF
--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -92,6 +92,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self.indent = f'{old_indent}   '
 		if hasattr(obj, 'subcons'):
 			for sc in obj.subcons:
+				self.append()
 				self._subcon_handlers.get(type(sc), self._default_handler)(sc)
 
 		elif hasattr(obj, 'subcon'):
@@ -111,16 +112,16 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		def _val_to_str(value):
 			return f'0{base}{value:0{size}{base}}'
 
-
 		for v, k in obj.ksymapping.items():
-			self.append(f'.. py:attribute:: {str(self.name).replace("::", ".")}.{k}')
-			self.append(f'   :type: {obj.subcon.__class__.__name__}<{size}>')
-			self.append(f'   :value: {_val_to_str(v)}')
 			self.append()
+			self.append(f'.. py:attribute:: {str(self.name).replace("::", ".")}.{k}')
+			self.append(f'   :type: {self._typename(obj.subcon)}<{size}>')
+			self.append(f'   :value: {_val_to_str(v)}')
+			self.append( '   :noindex:')
 
 		if hasattr(obj, 'docs'):
-			self.append(obj.docs)
 			self.append()
+			self.append(obj.docs)
 
 	def _renamed_handler(self, obj, is_header = False):
 		if is_header:
@@ -153,34 +154,34 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		elif isinstance(obj, construct.BytesInteger):
 			unit = 'byte'
 
-		self.append(f'{signedness} {obj.sizeof()} {unit} integer.')
 		self.append()
+		self.append(f'{signedness} {obj.sizeof()} {unit} integer.')
 
 		if hasattr(obj, 'docs'):
-			self.append(obj.docs)
 			self.append()
+			self.append(obj.docs)
 
 	def _formatfield_handler(self, obj, _ = None):
 		endian = FIELD_ENDAIN[obj.fmtstr[0]]['endian']
 		specs  = list(map(lambda s: FIELD_SPEC[s], obj.fmtstr[1:]))
 
+		self.append()
 		self.append(f'**Endian:** {endian!s}')
 		self.append()
 		self.append(f'**Size:** {obj.length}')
 		self.append()
 		self.append(f'**Underlying Types:**')
-		self.append()
 		for s in specs:
+			self.append()
 			self.append(f'  Type: {s["ptype"]}')
 			self.append()
 			self.append(f'  Size: {s["std_size"]}')
 			self.append()
 			self.append(f'  Sign: {s["signed"]!s}')
-			self.append()
 
 		if hasattr(obj, 'docs'):
-			self.append(obj.docs)
 			self.append()
+			self.append(obj.docs)
 
 	def _switch_handler(self, obj, _ = None):
 		def _recompose_keyfunc(func):
@@ -198,8 +199,8 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 
 		if hasattr(obj, 'docs'):
-			self.append(obj.docs)
 			self.append()
+			self.append(obj.docs)
 
 	def _struct_handler(self, obj : construct.Struct, is_header = False):
 		if is_header:
@@ -224,8 +225,8 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 	def _default_handler(self, obj, _ = None):
 		log.warning(f'No specialized handling for {type(obj)}', color = 'yellow')
 		if hasattr(obj, 'docs'):
-			self.append(obj.docs)
 			self.append()
+			self.append(obj.docs)
 
 		self._recuse(obj)
 
@@ -233,10 +234,8 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 	# for type that don't have special parsing needs
 	def _empty_handler(self, obj, _ = None):
 		if hasattr(obj, 'docs'):
-			self.append(obj.docs)
 			self.append()
-
-		# self._recuse(obj)
+			self.append(obj.docs)
 
 	# -- Sphinx Documenter boilerplate bits -- #
 

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -2,6 +2,7 @@
 from sphinx.util        import logging
 from sphinx.ext.autodoc import ModuleLevelDocumenter
 from enum import IntEnum, unique, auto
+from typing import Union
 import construct
 
 from ..consts           import DOMAIN, FIELD_ENDAIN, FIELD_SPEC
@@ -188,7 +189,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self._recuse(obj, indent = False)
 		self.size_mode = size_mode
 
-	def _numeric_handler(self, obj):
+	def _numeric_handler(self, obj : Union[construct.BitsInteger,construct.BytesInteger]):
 		signedness = 'Signed' if obj.signed else 'Unsigned'
 		if isinstance(obj, construct.BitsInteger):
 			unit = 'bit'
@@ -202,7 +203,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append()
 			self.append(obj.docs)
 
-	def _formatfield_handler(self, obj):
+	def _formatfield_handler(self, obj : construct.FormatField):
 		endian = FIELD_ENDAIN[obj.fmtstr[0]]['endian']
 		specs  = list(map(lambda s: FIELD_SPEC[s], obj.fmtstr[1:]))
 

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -210,10 +210,8 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		else:
 			self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
 
-	def _const_handler(self, obj : construct.Const, _ = None):
-		self.append(f':value: {obj.value}')
-		subcon = obj.subcon
-		self._subcon_handlers.get(type(subcon), self._default_handler)(subcon)
+	def _const_handler(self, obj : construct.Const):
+		self._recuse(obj, indent = False)
 
 	# The default handler for things we miss
 	def _default_handler(self, obj):

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -84,12 +84,13 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		else:
 			self.add_line('', self.get_sourcename())
 
-	def _recuse(self, obj):
+	def _recuse(self, obj, indent : bool = True):
 		if obj in _documented_subcon_instances:
 			return
+		if indent:
+			old_indent = self.indent
+			self.indent = f'{old_indent}   '
 
-		old_indent = self.indent
-		self.indent = f'{old_indent}   '
 		if hasattr(obj, 'subcons'):
 			for sc in obj.subcons:
 				self.append()
@@ -98,7 +99,8 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		elif hasattr(obj, 'subcon'):
 			self._subcon_handlers.get(type(obj.subcon), self._default_handler)(obj.subcon)
 
-		self.indent = old_indent
+		if indent:
+			self.indent = old_indent
 		_documented_subcon_instances.append(obj)
 
 	# -- Type Handlers -- #

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -99,7 +99,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		if obj in _documented_subcon_instances:
 			name = _documented_subcon_instances[obj]
 			self.append()
-			self.append(f'See: :py:attr:`{name}`')
+			self.append(f'   See: :py:attr:`{name}`')
 			return
 
 		if indent:
@@ -175,7 +175,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self.append()
 		# self.append(f'.. _{self._mk_tgt_name(obj)}:')
 		self.append(f'.. py:attribute:: {self._valname(obj)}')
-		self.append(f'   :type: {self._typename(obj.subcon)}')
+		self.append(f'   :type: {self._typename(obj)}')
 		if hasattr(obj.subcon, 'value'):
 			self.append(f'   :value: {obj.subcon.value}')
 		self._recuse(obj)

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -50,6 +50,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			construct.Const         : self._const_handler,
 			construct.Padded        : self._padded_handler,
 			construct.Rebuild       : self._rebuild_handler,
+			construct.GreedyRange   : self._greedy_range_handler,
 		}
 
 	def _sanitize_name(self, txt):
@@ -267,6 +268,12 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		if hasattr(obj, 'docs'):
 			self.append()
 			self.append(obj.docs)
+
+	def _greedy_range_handler(self, obj : construct.GreedyRange):
+		self.append()
+		self.append(f'.. py:attribute:: {self.name}.GreedyRange')
+		self.append(f'   :type: {self._typename(obj.subcon)}')
+		self._recuse(obj)
 
 	# The default handler for things we miss
 	def _default_handler(self, obj):

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -146,8 +146,8 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 
 	# Unwrap the construct.core.Transformed subcon
-	def _transformed_handler(self, obj, _ = None):
-		self._recuse(obj.subcon)
+	def _transformed_handler(self, obj):
+		self._recuse(obj, indent = False)
 
 	def _numeric_handler(self, obj):
 		signedness = 'Signed' if obj.signed else 'Unsigned'

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -138,7 +138,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 				self.append()
 				self._recuse(obj)
 			else:
-				self.append(f'`See: "{obj.name}" <{self._mk_tgt_name(obj)}>`_')
+				self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
 				self.append()
 
 

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -50,6 +50,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			construct.Pass.__class__: self._empty_handler,
 			construct.Const         : self._const_handler,
 			construct.Padded        : self._padded_handler,
+			construct.Rebuild       : self._rebuild_handler,
 		}
 
 	def _documented_instance(self, obj):
@@ -266,6 +267,14 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self.append()
 		self.append(f'Data block padded to {obj.length} bytes')
 		self._recuse(obj)
+		if hasattr(obj, 'docs'):
+			self.append()
+			self.append(obj.docs)
+
+	def _rebuild_handler(self, obj : construct.Rebuild):
+		self.append()
+		self.append(f'Runtime rebuilt constant')
+		self._recuse(obj, indent = False)
 		if hasattr(obj, 'docs'):
 			self.append()
 			self.append(obj.docs)

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -69,10 +69,21 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			construct.Restreamed,
 		)
 
-		if isinstance(obj, containers):
+		prefix = ''
+		while isinstance(obj, containers):
+			if (
+				(isinstance(obj, construct.Transformed) and obj.decodefunc == construct.bytes2bits) or
+				(isinstance(obj, construct.Restreamed) and obj.decoder == construct.bytes2bits)
+			):
+				prefix = 'Bit'
+			elif (
+				(isinstance(obj, construct.Transformed) and obj.decodefunc == construct.bits2bytes) or
+				(isinstance(obj, construct.Restreamed) and obj.decoder == construct.bits2bytes)
+			):
+				prefix = ''
 			obj = obj.subcon
 
-		return obj.__class__.__name__
+		return f'{prefix}{obj.__class__.__name__}'
 
 	# Attempts to get the name of a value
 	def _valname(self, obj : construct.Construct):

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -243,17 +243,16 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		key = _recompose_keyfunc(obj.keyfunc)
 
 		for k, v in obj.cases.items():
-			self.append(f'.. py:attribute:: {self._typename(v)}')
-			self.append(f'   :type: {self._valname(v)}')
-			self.append(f'   :value: {k}')
-			self.append( '   :noindex:')
 			self.append()
+			self.append(f'.. py:attribute:: {self.name}.{k}')
+			self.append(f'   :type: {self._typename(v)}')
+			self.append( '   :noindex:')
 			self._recuse(v)
-
 
 		if hasattr(obj, 'docs'):
 			self.append()
 			self.append(obj.docs)
+		_documented_subcon_instances[obj] = self.name
 
 	def _struct_handler(self, obj : construct.Struct):
 		self._recuse(obj, indent = False)
@@ -315,7 +314,13 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 	def add_content(self, content, no_docstring = False):
 		super().add_content(content, no_docstring)
-		self._recuse(self.object, indent = False)
+		name = self.name
+		self.name = f'{self.modname}.{self.format_name()}'
+		if isinstance(self.object, construct.Switch):
+			self._switch_handler(self.object)
+		else:
+			self._recuse(self.object, indent = False)
+		self.name = name
 
 	def get_doc(self, ignore: int = None):
 		pass

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -37,6 +37,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self.size_mode = SizeMode.BYTES
 		self._subcon_handlers = {
 			construct.Enum          : self._enum_handler,
+			construct.FlagsEnum     : self._flags_enum_handler,
 			construct.Renamed       : self._renamed_handler,
 			construct.Transformed   : self._transformed_handler,
 			construct.Restreamed    : self._restreamed_handler,
@@ -127,6 +128,30 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			return f'0{base}{value:0{size}{base}}'
 
 		for v, k in obj.ksymapping.items():
+			self.append()
+			self.append(f'.. py:attribute:: {str(self.name).replace("::", ".")}.{k}')
+			self.append(f'   :type: {self._typename(obj.subcon)}<{size}>')
+			self.append(f'   :value: {_val_to_str(v)}')
+			self.append( '   :noindex:')
+
+		if hasattr(obj, 'docs'):
+			self.append()
+			self.append(obj.docs)
+
+	def _flags_enum_handler(self, obj):
+		size   = obj.subcon.sizeof()
+		if self.size_mode == SizeMode.BYTES:
+			base = 'x'
+			size = size * 2
+		else:
+			do_hex = (size & 3) == 0
+			base   = 'x' if do_hex else 'b'
+			size   = (size >> 2) if do_hex else size
+
+		def _val_to_str(value):
+			return f'0x{value:0{size}{base}}'
+
+		for v, k in obj.reverseflags.items():
 			self.append()
 			self.append(f'.. py:attribute:: {str(self.name).replace("::", ".")}.{k}')
 			self.append(f'   :type: {self._typename(obj.subcon)}<{size}>')

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from sphinx.util        import logging
-from sphinx.ext.autodoc import Documenter
+from sphinx.ext.autodoc import ModuleLevelDocumenter
 import construct
 
 from ..consts           import DOMAIN, FIELD_ENDAIN, FIELD_SPEC
@@ -17,13 +17,12 @@ __all__ = (
 
 _documented_subcon_instances = []
 
-class SubconstructDocumenter(Documenter):
+class SubconstructDocumenter(ModuleLevelDocumenter):
 	# domain         = DOMAIN
 	objtype          = 'subconstruct'
-	directivetype    = Documenter.objtype
 	directivetype    = 'attribute'
-	priority         = Documenter.priority + 100
-	option_spec      = dict(Documenter.option_spec)
+	priority         = ModuleLevelDocumenter.priority + 100
+	option_spec      = dict(ModuleLevelDocumenter.option_spec)
 	titles_allowed   = True
 	_subcon_handlers = {}
 
@@ -232,7 +231,6 @@ class SubconstructDocumenter(Documenter):
 
 		# self._recuse(obj)
 
-
 	# -- Sphinx Documenter boilerplate bits -- #
 
 	@classmethod
@@ -247,7 +245,5 @@ class SubconstructDocumenter(Documenter):
 		super().add_content(content, no_docstring)
 		self._subcon_handlers.get(type(self.object), self._default_handler)(self.object)
 
-	def resolve_name(self, modname, parents, path, base):
-		return modname, parents + [base]
-
-
+	def get_doc(self, ignore: int = None):
+		pass

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -90,7 +90,11 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 	def _recuse(self, obj, indent : bool = True):
 		if obj in _documented_subcon_instances:
+			name = _documented_subcon_instances[obj]
+			self.append()
+			self.append(f'See: :py:attr:`{name}`')
 			return
+
 		if indent:
 			old_indent = self.indent
 			self.indent = f'{old_indent}   '

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -91,7 +91,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 	def append(self, text = None):
 		if text is not None:
-			self.add_line(f'{self.indent}{text}', self.get_sourcename())
+			self.add_line(text, self.get_sourcename())
 		else:
 			self.add_line('', self.get_sourcename())
 
@@ -236,11 +236,13 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append()
 			self.append(obj.docs)
 
-	def _switch_handler(self, obj : construct.Switch):
-		def _recompose_keyfunc(func):
+	def _switch_handler(self, obj : construct.Switch, header : bool = True):
+		def _recompose_keyfunc(func : construct.Path):
 			return func
 
-		key = _recompose_keyfunc(obj.keyfunc)
+		if header:
+			key = _recompose_keyfunc(obj.keyfunc)
+			self.append(f':value: {key}')
 
 		for k, v in obj.cases.items():
 			self.append()
@@ -311,13 +313,15 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 	def add_directive_header(self, sig):
 		super().add_directive_header(sig)
 		self.append(f'   :type: {self._typename(self.object)}')
+		if isinstance(self.object, construct.Switch):
+			self.append(f'   :value: {self.object.keyfunc}')
 
 	def add_content(self, content, no_docstring = False):
 		super().add_content(content, no_docstring)
 		name = self.name
 		self.name = f'{self.modname}.{self.format_name()}'
 		if isinstance(self.object, construct.Switch):
-			self._switch_handler(self.object)
+			self._switch_handler(self.object, header = False)
 		else:
 			self._recuse(self.object, indent = False)
 		self.name = name

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -244,6 +244,10 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			key = _recompose_keyfunc(obj.keyfunc)
 			self.append(f':value: {key}')
 
+		if obj in _documented_subcon_instances:
+			self._recurse(obj, indent = False)
+			return
+
 		for k, v in obj.cases.items():
 			self.append()
 			self.append(f'.. py:attribute:: {self.name}.{k}')

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -159,7 +159,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			size   = (size >> 2) if do_hex else size
 
 		def _val_to_str(value):
-			return f'0x{value:0{size}{base}}'
+			return f'0{base}{value:0{size}{base}}'
 
 		for v, k in obj.reverseflags.items():
 			self.append()

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -182,9 +182,9 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 	# Unwrap the bits/bytes mode change construct.core.Restreamed subcon
 	def _restreamed_handler(self, obj : construct.Restreamed):
 		size_mode = self.size_mode
-		if obj.decoderunit == 8:
+		if obj.decoder == construct.bytes2bits:
 			self.size_mode = SizeMode.BITS
-		elif obj.decoderunit == 1:
+		elif obj.decoder == construct.bits2bytes:
 			self.size_mode = SizeMode.BYTES
 		self._recuse(obj, indent = False)
 		self.size_mode = size_mode

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from sphinx.util        import logging
 from sphinx.ext.autodoc import ModuleLevelDocumenter
-from enum import IntEnum, unique, auto
-from typing import Union
+from enum               import IntEnum, unique, auto
+from typing             import Union
 import construct
 
 from ..consts           import DOMAIN, FIELD_ENDAIN, FIELD_SPEC

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -49,6 +49,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			construct.Struct        : self._struct_handler,
 			construct.Pass.__class__: self._empty_handler,
 			construct.Const         : self._const_handler,
+			construct.Padded        : self._padded_handler,
 		}
 
 	def _documented_instance(self, obj):
@@ -265,6 +266,14 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 	def _const_handler(self, obj : construct.Const):
 		self._recuse(obj, indent = False)
+
+	def _padded_handler(self, obj : construct.Padded):
+		self.append()
+		self.append(f'Data block padded to {obj.length} bytes')
+		self._recuse(obj)
+		if hasattr(obj, 'docs'):
+			self.append()
+			self.append(obj.docs)
 
 	# The default handler for things we miss
 	def _default_handler(self, obj):

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -95,7 +95,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		else:
 			self.add_line('', self.get_sourcename())
 
-	def _recuse(self, obj, indent : bool = True):
+	def _recurse(self, obj, indent : bool = True):
 		if obj in _documented_subcon_instances:
 			name = _documented_subcon_instances[obj]
 			self.append()
@@ -178,7 +178,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self.append(f'   :type: {self._typename(obj)}')
 		if hasattr(obj.subcon, 'value'):
 			self.append(f'   :value: {obj.subcon.value}')
-		self._recuse(obj)
+		self._recurse(obj)
 
 	# Unwrap the bits/bytes mode change construct.core.Transformed subcon
 	def _transformed_handler(self, obj : construct.Transformed):
@@ -187,7 +187,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.size_mode = SizeMode.BITS
 		elif obj.decodefunc == construct.bits2bytes:
 			self.size_mode = SizeMode.BYTES
-		self._recuse(obj, indent = False)
+		self._recurse(obj, indent = False)
 		self.size_mode = size_mode
 
 	# Unwrap the bits/bytes mode change construct.core.Restreamed subcon
@@ -197,7 +197,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.size_mode = SizeMode.BITS
 		elif obj.decoder == construct.bits2bytes:
 			self.size_mode = SizeMode.BYTES
-		self._recuse(obj, indent = False)
+		self._recurse(obj, indent = False)
 		self.size_mode = size_mode
 
 	def _numeric_handler(self, obj : Union[construct.BitsInteger,construct.BytesInteger]):
@@ -249,7 +249,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append(f'.. py:attribute:: {self.name}.{k}')
 			self.append(f'   :type: {self._typename(v)}')
 			self.append( '   :noindex:')
-			self._recuse(v)
+			self._recurse(v)
 
 		if hasattr(obj, 'docs'):
 			self.append()
@@ -257,19 +257,19 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		_documented_subcon_instances[obj] = self.name
 
 	def _struct_handler(self, obj : construct.Struct):
-		self._recuse(obj, indent = False)
+		self._recurse(obj, indent = False)
 
 		if hasattr(obj, 'docs'):
 			self.append()
 			self.append(obj.docs)
 
 	def _const_handler(self, obj : construct.Const):
-		self._recuse(obj, indent = False)
+		self._recurse(obj, indent = False)
 
 	def _padded_handler(self, obj : construct.Padded):
 		self.append()
 		self.append(f'Data block padded to {obj.length} bytes')
-		self._recuse(obj)
+		self._recurse(obj)
 		if hasattr(obj, 'docs'):
 			self.append()
 			self.append(obj.docs)
@@ -277,7 +277,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 	def _rebuild_handler(self, obj : construct.Rebuild):
 		self.append()
 		self.append(f'Runtime rebuilt constant')
-		self._recuse(obj, indent = False)
+		self._recurse(obj, indent = False)
 		if hasattr(obj, 'docs'):
 			self.append()
 			self.append(obj.docs)
@@ -286,7 +286,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self.append()
 		self.append(f'.. py:attribute:: {self.name}.GreedyRange')
 		self.append(f'   :type: {self._typename(obj.subcon)}')
-		self._recuse(obj)
+		self._recurse(obj)
 
 	# The default handler for things we miss
 	def _default_handler(self, obj):
@@ -295,7 +295,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append()
 			self.append(obj.docs)
 
-		self._recuse(obj)
+		self._recurse(obj)
 
 	# Not quite the default handler, but an empty handler
 	# for type that don't have special parsing needs
@@ -323,7 +323,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		if isinstance(self.object, construct.Switch):
 			self._switch_handler(self.object, header = False)
 		else:
-			self._recuse(self.object, indent = False)
+			self._recurse(self.object, indent = False)
 		self.name = name
 
 	def get_doc(self, ignore: int = None):

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -103,7 +103,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 	# -- Type Handlers -- #
 
-	def _enum_handler(self, obj, _ = None):
+	def _enum_handler(self, obj):
 		size   = obj.subcon.sizeof()
 		do_hex = (size & 3) == 0
 		base   = 'x' if do_hex else 'b'
@@ -147,7 +147,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 	def _transformed_handler(self, obj, _ = None):
 		self._recuse(obj.subcon)
 
-	def _numeric_handler(self, obj, _ = None):
+	def _numeric_handler(self, obj):
 		signedness = 'Signed' if obj.signed else 'Unsigned'
 		if isinstance(obj, construct.BitsInteger):
 			unit = 'bit'
@@ -161,7 +161,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append()
 			self.append(obj.docs)
 
-	def _formatfield_handler(self, obj, _ = None):
+	def _formatfield_handler(self, obj):
 		endian = FIELD_ENDAIN[obj.fmtstr[0]]['endian']
 		specs  = list(map(lambda s: FIELD_SPEC[s], obj.fmtstr[1:]))
 
@@ -183,7 +183,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append()
 			self.append(obj.docs)
 
-	def _switch_handler(self, obj, _ = None):
+	def _switch_handler(self, obj : construct.Switch):
 		def _recompose_keyfunc(func):
 			return func
 
@@ -222,7 +222,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		self._subcon_handlers.get(type(subcon), self._default_handler)(subcon)
 
 	# The default handler for things we miss
-	def _default_handler(self, obj, _ = None):
+	def _default_handler(self, obj):
 		log.warning(f'No specialized handling for {type(obj)}', color = 'yellow')
 		if hasattr(obj, 'docs'):
 			self.append()
@@ -232,7 +232,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 	# Not quite the default handler, but an empty handler
 	# for type that don't have special parsing needs
-	def _empty_handler(self, obj, _ = None):
+	def _empty_handler(self, obj):
 		if hasattr(obj, 'docs'):
 			self.append()
 			self.append(obj.docs)
@@ -245,7 +245,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 
 	def add_directive_header(self, sig):
 		super().add_directive_header(sig)
-		self._subcon_handlers.get(type(self.object), self._default_handler)(self.object, True)
+		self.append(f'   :type: {self._typename(self.object)}')
 
 	def add_content(self, content, no_docstring = False):
 		super().add_content(content, no_docstring)

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -204,19 +204,16 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append()
 			self.append(obj.docs)
 
-	def _struct_handler(self, obj : construct.Struct, is_header = False):
-		if is_header:
-			self.append(f'   :type: {self._typename(obj)}')
-		else:
-			di = self._documented_instance(obj)
-			if di is None:
-				if hasattr(obj, 'docs'):
-					self.append(obj.docs)
-					self.append()
-				self._recuse(obj)
-			else:
-				self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
+	def _struct_handler(self, obj : construct.Struct):
+		di = self._documented_instance(obj)
+		if di is None:
+			self._recuse(obj, indent = False)
+
+			if hasattr(obj, 'docs'):
 				self.append()
+				self.append(obj.docs)
+		else:
+			self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
 
 	def _const_handler(self, obj : construct.Const, _ = None):
 		self.append(f':value: {obj.value}')

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -30,7 +30,6 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 	priority         = ModuleLevelDocumenter.priority + 100
 	option_spec      = dict(ModuleLevelDocumenter.option_spec)
 	titles_allowed   = True
-	_subcon_handlers = {}
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
@@ -52,11 +51,6 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			construct.Padded        : self._padded_handler,
 			construct.Rebuild       : self._rebuild_handler,
 		}
-
-	def _documented_instance(self, obj):
-		if obj in _documented_subcon_instances:
-			return obj
-		return None
 
 	def _sanitize_name(self, txt):
 		tgt_chars = (' ', '.', '<', '>', ':')
@@ -165,18 +159,13 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append(obj.docs)
 
 	def _renamed_handler(self, obj : construct.Renamed):
-		di = self._documented_instance(obj)
-		if di is None:
-			self.append()
-			# self.append(f'.. _{self._mk_tgt_name(obj)}:')
-			self.append(f'.. py:attribute:: {self._valname(obj)}')
-			self.append(f'   :type: {self._typename(obj.subcon)}')
-			if hasattr(obj.subcon, 'value'):
-				self.append(f'   :value: {obj.subcon.value}')
-			self._recuse(obj)
-		else:
-			self.append()
-			self.append(f'See: :py:attr:`{obj.name}<{_documented_subcon_instances[obj]}.{obj.name}>`')
+		self.append()
+		# self.append(f'.. _{self._mk_tgt_name(obj)}:')
+		self.append(f'.. py:attribute:: {self._valname(obj)}')
+		self.append(f'   :type: {self._typename(obj.subcon)}')
+		if hasattr(obj.subcon, 'value'):
+			self.append(f'   :value: {obj.subcon.value}')
+		self._recuse(obj)
 
 	# Unwrap the bits/bytes mode change construct.core.Transformed subcon
 	def _transformed_handler(self, obj : construct.Transformed):
@@ -254,15 +243,11 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append(obj.docs)
 
 	def _struct_handler(self, obj : construct.Struct):
-		di = self._documented_instance(obj)
-		if di is None:
-			self._recuse(obj, indent = False)
+		self._recuse(obj, indent = False)
 
-			if hasattr(obj, 'docs'):
-				self.append()
-				self.append(obj.docs)
-		else:
-			self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
+		if hasattr(obj, 'docs'):
+			self.append()
+			self.append(obj.docs)
 
 	def _const_handler(self, obj : construct.Const):
 		self._recuse(obj, indent = False)

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -125,25 +125,20 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append()
 			self.append(obj.docs)
 
-	def _renamed_handler(self, obj, is_header = False):
-		if is_header:
-			# self.append(f'.. py:attribute:: {obj.name}')
-			# self.append(f'   :module: {self.modname}')
-			self.append(f'   :type: {self._typename(obj.subcon)}')
+	def _renamed_handler(self, obj : construct.Renamed):
+		di = self._documented_instance(obj)
+		if di is None:
+			self.append()
+			# self.append(f'.. _{self._mk_tgt_name(obj)}:')
+			self.append(f'.. py:attribute:: {obj.name}')
+			self.append(f'   :type: {self._typename(obj.subcon)} (Renamed)')
+			if hasattr(obj.subcon, 'value'):
+				self.append(f'   :value: {obj.subcon.value}')
+			self.append( '   :noindex:')
+			self._recuse(obj)
 		else:
-			di = self._documented_instance(obj)
-			if di is None:
-				# self.append(f'.. _{self._mk_tgt_name(obj)}:')
-				self.append()
-				self.append(f'.. py:attribute:: {obj.name}')
-				self.append(f'   :type: {self._typename(obj.subcon)}')
-				self.append( '   :noindex:')
-				self.append()
-				self._recuse(obj)
-			else:
-				self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
-				self.append()
-
+			self.append()
+			self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
 
 	# Unwrap the construct.core.Transformed subcon
 	def _transformed_handler(self, obj):

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -39,6 +39,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			construct.Enum          : self._enum_handler,
 			construct.Renamed       : self._renamed_handler,
 			construct.Transformed   : self._transformed_handler,
+			construct.Restreamed    : self._restreamed_handler,
 			construct.BitsInteger   : self._numeric_handler,
 			construct.BytesInteger  : self._numeric_handler,
 			construct.Flag.__class__: self._empty_handler,
@@ -66,6 +67,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		containers = (
 			construct.Renamed,
 			construct.Transformed,
+			construct.Restreamed,
 		)
 
 		if isinstance(obj, containers):
@@ -156,6 +158,16 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 		if obj.decodefunc == construct.bytes2bits:
 			self.size_mode = SizeMode.BITS
 		elif obj.decodefunc == construct.bits2bytes:
+			self.size_mode = SizeMode.BYTES
+		self._recuse(obj, indent = False)
+		self.size_mode = size_mode
+
+	# Unwrap the bits/bytes mode change construct.core.Restreamed subcon
+	def _restreamed_handler(self, obj : construct.Restreamed):
+		size_mode = self.size_mode
+		if obj.decoderunit == 8:
+			self.size_mode = SizeMode.BITS
+		elif obj.decoderunit == 1:
 			self.size_mode = SizeMode.BYTES
 		self._recuse(obj, indent = False)
 		self.size_mode = size_mode

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -201,16 +201,18 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			self.append(obj.docs)
 			self.append()
 
-	def _struct_handler(self, obj, _ = None):
-			for s in obj.subcons:
-				self.append(f'.. py:attribute:: {self._typename(s)}')
-				self.append(f'   :type: {self._valname(s)}')
-				self.append( '   :noindex:')
-				self.append()
-				self._recuse(s)
-
-			if hasattr(obj, 'docs'):
-				self.append(obj.docs)
+	def _struct_handler(self, obj : construct.Struct, is_header = False):
+		if is_header:
+			self.append(f'   :type: {self._typename(obj)}')
+		else:
+			di = self._documented_instance(obj)
+			if di is None:
+				if hasattr(obj, 'docs'):
+					self.append(obj.docs)
+					self.append()
+				self._recuse(obj)
+			else:
+				self.append(f'See: :py:attr:`{obj.name}<{obj.name}>`')
 				self.append()
 
 	def _const_handler(self, obj : construct.Const, _ = None):

--- a/sphinx_construct/documenters/subcon.py
+++ b/sphinx_construct/documenters/subcon.py
@@ -40,6 +40,7 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 			construct.Switch        : self._switch_handler,
 			construct.Struct        : self._struct_handler,
 			construct.Pass.__class__: self._empty_handler,
+			construct.Const         : self._const_handler,
 		}
 
 	def _documented_instance(self, obj):
@@ -212,6 +213,10 @@ class SubconstructDocumenter(ModuleLevelDocumenter):
 				self.append(obj.docs)
 				self.append()
 
+	def _const_handler(self, obj : construct.Const, _ = None):
+		self.append(f':value: {obj.value}')
+		subcon = obj.subcon
+		self._subcon_handlers.get(type(subcon), self._default_handler)(subcon)
 
 	# The default handler for things we miss
 	def _default_handler(self, obj, _ = None):


### PR DESCRIPTION
This PR does a few things, but the main thing is adding support for several new construct entities such as construct.Const and construct.Switch.

It additionally fixes cross-referencing and cleans up the recursion and header patterns + disables docstring extraction as this will always pull the construct docstrings due to how construct works.